### PR TITLE
Computed greeks leveraging automatic differentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ jaxfin/examples/requirements.txt
 test_report.xml
 test_report.html
 
+## Coverage results
+.coverage
+htmlcov/
+
 # Version file
 jaxfin.VERSION
 version.txt

--- a/jaxfin/price_engine/black/__init__.py
+++ b/jaxfin/price_engine/black/__init__.py
@@ -1,5 +1,6 @@
 """Option price computed with the Black'76 model"""
-from jaxfin.price_engine.black.black_model import black_price, delta_black, gamma_black
+from jaxfin.price_engine.black.black_model import (black_price, delta_black,
+                                                   gamma_black)
 
 future_option_price = black_price
 future_option_delta = delta_black

--- a/jaxfin/price_engine/black/__init__.py
+++ b/jaxfin/price_engine/black/__init__.py
@@ -1,4 +1,6 @@
 """Option price computed with the Black'76 model"""
-from jaxfin.price_engine.black.black_model import black_price
+from jaxfin.price_engine.black.black_model import black_price, delta_black, gamma_black
 
 future_option_price = black_price
+future_option_delta = delta_black
+future_option_gamma = gamma_black

--- a/jaxfin/price_engine/black/__init__.py
+++ b/jaxfin/price_engine/black/__init__.py
@@ -1,6 +1,5 @@
 """Option price computed with the Black'76 model"""
-from jaxfin.price_engine.black.black_model import (black_price, delta_black,
-                                                   gamma_black)
+from jaxfin.price_engine.black.black_model import black_price, delta_black, gamma_black
 
 future_option_price = black_price
 future_option_delta = delta_black

--- a/jaxfin/price_engine/black/black_model.py
+++ b/jaxfin/price_engine/black/black_model.py
@@ -52,4 +52,6 @@ def black_price(
 
     undiscounted_forwards = forwards - strikes
     undiscouted_puts = undiscounted_calls - undiscounted_forwards
-    return jnp.exp((-1 * discount_rates) * expires) * jnp.where(are_calls, undiscounted_calls, undiscouted_puts)
+    return jnp.exp((-1 * discount_rates) * expires) * jnp.where(
+        are_calls, undiscounted_calls, undiscouted_puts
+    )

--- a/jaxfin/price_engine/black/black_model.py
+++ b/jaxfin/price_engine/black/black_model.py
@@ -13,7 +13,7 @@ def black_price(
     strikes: jax.Array,
     expires: jax.Array,
     vols: jax.Array,
-    discount_rates: jax.Array = None,
+    discount_rates: jax.Array,
     dividend_rates: jax.Array = None,
     are_calls: jax.Array = None,
     dtype: jnp.dtype = None,
@@ -37,9 +37,6 @@ def black_price(
         [spots, strikes, expires, vols], dtype
     )
 
-    if discount_rates is None:
-        discount_rates = jnp.zeros(shape, dtype=dtype)
-
     if dividend_rates is None:
         dividend_rates = jnp.zeros(shape, dtype=dtype)
 
@@ -55,4 +52,4 @@ def black_price(
 
     undiscounted_forwards = forwards - strikes
     undiscouted_puts = undiscounted_calls - undiscounted_forwards
-    return discount_factors * jnp.where(are_calls, undiscounted_calls, undiscouted_puts)
+    return jnp.exp((-1 * discount_rates) * expires) * jnp.where(are_calls, undiscounted_calls, undiscouted_puts)

--- a/jaxfin/price_engine/black/black_model.py
+++ b/jaxfin/price_engine/black/black_model.py
@@ -3,6 +3,7 @@ Black '76 prices for options on forwards and futures
 """
 import jax
 import jax.numpy as jnp
+from jax import grad, vmap
 
 from ..common import compute_undiscounted_call_prices
 from ..utils import cast_arrays
@@ -54,4 +55,116 @@ def black_price(
     undiscouted_puts = undiscounted_calls - undiscounted_forwards
     return jnp.exp((-1 * discount_rates) * expires) * jnp.where(
         are_calls, undiscounted_calls, undiscouted_puts
+    )
+
+
+def _delta_black(
+    spots: jax.Array,
+    strikes: jax.Array,
+    expires: jax.Array,
+    vols: jax.Array,
+    discount_rates: jax.Array,
+    dividend_rates: jax.Array,
+    are_calls: jax.Array = None,
+    dtype: jnp.dtype = None,
+) -> jax.Array:
+    """
+    Compute the option deltas for european options using the Black '76 model.
+
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates. Defaults to None.
+    :param dividend_rates: (jax.Array): Array of dividend rates. Defaults to None.
+    :param are_calls: (jax.Array): Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of computed option deltas.
+    """
+    return grad(black_price, argnums=0)(
+        spots, strikes, expires, vols, discount_rates, dividend_rates, are_calls, dtype
+    )
+
+
+def _gamma_black(
+    spots: jax.Array,
+    strikes: jax.Array,
+    expires: jax.Array,
+    vols: jax.Array,
+    discount_rates: jax.Array,
+    dividend_rates: jax.Array,
+    are_calls: jax.Array = None,
+    dtype: jnp.dtype = None,
+) -> jax.Array:
+    """
+    Compute the option gammas for european options using the Black '76 model.
+
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates. Defaults to None.
+    :param dividend_rates: (jax.Array): Array of dividend rates. Defaults to None.
+    :param are_calls: (jax.Array): Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of computed option gammas.
+    """
+    return grad(grad(black_price, argnums=0), argnums=0)(
+        spots, strikes, expires, vols, discount_rates, dividend_rates, are_calls, dtype
+    )
+
+
+def delta_black(
+    spots: jax.Array,
+    strikes: jax.Array,
+    expires: jax.Array,
+    vols: jax.Array,
+    discount_rates: jax.Array,
+    dividend_rates: jax.Array = None,
+    are_calls: jax.Array = None,
+    dtype: jnp.dtype = None,
+) -> jax.Array:
+    """
+    Compute the option deltas for european options using the Black '76 model. (vectorized)
+
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates. Defaults to None.
+    :param dividend_rates: (jax.Array): Array of dividend rates. Defaults to None.
+    :param are_calls: (jax.Array): Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of computed option deltas.
+    """
+    return vmap(_delta_black, in_axes=(0, 0, 0, 0, 0, 0, 0, None))(
+        spots, strikes, expires, vols, discount_rates, dividend_rates, are_calls, dtype
+    )
+
+
+def gamma_black(
+    spots: jax.Array,
+    strikes: jax.Array,
+    expires: jax.Array,
+    vols: jax.Array,
+    discount_rates: jax.Array,
+    dividend_rates: jax.Array = None,
+    are_calls: jax.Array = None,
+    dtype: jnp.dtype = None,
+) -> jax.Array:
+    """
+    Compute the option gammas for european options using the Black '76 model. (vectorized)
+
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates. Defaults to None.
+    :param dividend_rates: (jax.Array): Array of dividend rates. Defaults to None.
+    :param are_calls: (jax.Array): Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of computed option gammas.
+    """
+    return vmap(_gamma_black, in_axes=(0, 0, 0, 0, 0, 0, 0, None))(
+        spots, strikes, expires, vols, discount_rates, dividend_rates, are_calls, dtype
     )

--- a/jaxfin/price_engine/black_scholes/__init__.py
+++ b/jaxfin/price_engine/black_scholes/__init__.py
@@ -1,10 +1,12 @@
 """Option prices computed with the Black-Scholes module"""
-from jaxfin.price_engine.black_scholes.vanilla_options import (bs_price,
-                                                               delta_vanilla,
-                                                               gamma_vanilla,
-                                                               rho_vanilla,
-                                                               theta_vanilla,
-                                                               vega_vanilla)
+from jaxfin.price_engine.black_scholes.vanilla_options import (
+    bs_price,
+    delta_vanilla,
+    gamma_vanilla,
+    rho_vanilla,
+    theta_vanilla,
+    vega_vanilla,
+)
 
 european_price = bs_price
 delta_european = delta_vanilla

--- a/jaxfin/price_engine/black_scholes/__init__.py
+++ b/jaxfin/price_engine/black_scholes/__init__.py
@@ -3,8 +3,14 @@ from jaxfin.price_engine.black_scholes.vanilla_options import (
     bs_price,
     delta_vanilla,
     gamma_vanilla,
+    theta_vanilla,
+    rho_vanilla,
+    vega_vanilla
 )
 
 european_price = bs_price
 delta_european = delta_vanilla
 gamma_european = gamma_vanilla
+theta_european = theta_vanilla
+rho_european = rho_vanilla
+vega_european = vega_vanilla

--- a/jaxfin/price_engine/black_scholes/__init__.py
+++ b/jaxfin/price_engine/black_scholes/__init__.py
@@ -5,7 +5,7 @@ from jaxfin.price_engine.black_scholes.vanilla_options import (
     gamma_vanilla,
     theta_vanilla,
     rho_vanilla,
-    vega_vanilla
+    vega_vanilla,
 )
 
 european_price = bs_price

--- a/jaxfin/price_engine/black_scholes/__init__.py
+++ b/jaxfin/price_engine/black_scholes/__init__.py
@@ -1,12 +1,10 @@
 """Option prices computed with the Black-Scholes module"""
-from jaxfin.price_engine.black_scholes.vanilla_options import (
-    bs_price,
-    delta_vanilla,
-    gamma_vanilla,
-    theta_vanilla,
-    rho_vanilla,
-    vega_vanilla,
-)
+from jaxfin.price_engine.black_scholes.vanilla_options import (bs_price,
+                                                               delta_vanilla,
+                                                               gamma_vanilla,
+                                                               rho_vanilla,
+                                                               theta_vanilla,
+                                                               vega_vanilla)
 
 european_price = bs_price
 delta_european = delta_vanilla

--- a/jaxfin/price_engine/black_scholes/vanilla_options.py
+++ b/jaxfin/price_engine/black_scholes/vanilla_options.py
@@ -6,7 +6,6 @@ from jax import grad, vmap
 import jax.numpy as jnp
 
 from ..common import compute_discounted_call_prices
-from ..math import cum_normal, d1, density_normal
 from ..utils import cast_arrays
 
 
@@ -59,7 +58,7 @@ def _delta_vanilla(
     dtype: jnp.dtype = None,
 ) -> jax.Array:
     """
-    Calculate the delta of a call/put option under the BS model
+    Calculate the delta of a call/put option under the BS model (scalar version)
 
     :param spots: (jax.Array): Array of current asset prices.
     :param strikes: (jax.Array): Array of option strike prices.
@@ -70,7 +69,10 @@ def _delta_vanilla(
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (jax.Array): Array of delta of the given options.
     """
-    return grad(bs_price, argnums=0)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
+    return grad(bs_price, argnums=0)(
+        spots, strikes, expires, vols, discount_rates, are_calls, dtype
+    )
+
 
 def _gamma_vanilla(
     spots: jax.Array,
@@ -82,7 +84,7 @@ def _gamma_vanilla(
     dtype: jnp.dtype = None,
 ) -> jax.Array:
     """
-    Calculate the gamma of a european option under the BS model
+    Calculate the gamma of a european option under the BS model (scalar version)
 
     :param spots: (jax.Array): Array of current asset prices.
     :param strikes: (jax.Array): Array of option strike prices.
@@ -93,7 +95,10 @@ def _gamma_vanilla(
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (jax.Array): Array of gamma of the given options.
     """
-    return grad(grad(bs_price, argnums=0), argnums=0)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
+    return grad(grad(bs_price, argnums=0), argnums=0)(
+        spots, strikes, expires, vols, discount_rates, are_calls, dtype
+    )
+
 
 def _theta_vanilla(
     spots: jax.Array,
@@ -105,7 +110,7 @@ def _theta_vanilla(
     dtype: jnp.dtype = None,
 ) -> jax.Array:
     """
-    Calculate the theta of a european option under the BS model
+    Calculate the theta of a european option under the BS model (scalar version)
 
     :param spots: (jax.Array): Array of current asset prices.
     :param strikes: (jax.Array): Array of option strike prices.
@@ -116,7 +121,10 @@ def _theta_vanilla(
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (jax.Array): Array of theta of the given options.
     """
-    return grad(bs_price, argnums=2)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
+    return grad(bs_price, argnums=2)(
+        spots, strikes, expires, vols, discount_rates, are_calls, dtype
+    )
+
 
 def _vega_vanilla(
     spots: jax.Array,
@@ -128,7 +136,7 @@ def _vega_vanilla(
     dtype: jnp.dtype = None,
 ) -> jax.Array:
     """
-    Calculate the vega of a european option under the BS model
+    Calculate the vega of a european option under the BS model (scalar version)
 
     :param spots: (jax.Array): Array of current asset prices.
     :param strikes: (jax.Array): Array of option strike prices.
@@ -139,7 +147,10 @@ def _vega_vanilla(
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (jax.Array): Array of vega of the given options.
     """
-    return grad(bs_price, argnums=3)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
+    return grad(bs_price, argnums=3)(
+        spots, strikes, expires, vols, discount_rates, are_calls, dtype
+    )
+
 
 def _rho_vanilla(
     spots: jax.Array,
@@ -151,7 +162,7 @@ def _rho_vanilla(
     dtype: jnp.dtype = None,
 ) -> jax.Array:
     """
-    Calculate the rho of a european option under the BS model
+    Calculate the rho of a european option under the BS model (scalar version)
 
     :param spots: (jax.Array): Array of current asset prices.
     :param strikes: (jax.Array): Array of option strike prices.
@@ -162,12 +173,139 @@ def _rho_vanilla(
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (jax.Array): Array of rho of the given options.
     """
-    return grad(bs_price, argnums=4)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
+    return grad(bs_price, argnums=4)(
+        spots, strikes, expires, vols, discount_rates, are_calls, dtype
+    )
+
 
 # Vectorize version of the functions since we are dealing with arrays
 
-delta_vanilla = vmap(_delta_vanilla, in_axes=(0, 0, 0, 0, 0))
-gamma_vanilla = vmap(_gamma_vanilla, in_axes=(0, 0, 0, 0, 0))
-theta_vanilla = vmap(_theta_vanilla, in_axes=(0, 0, 0, 0, 0))
-vega_vanilla = vmap(_vega_vanilla, in_axes=(0, 0, 0, 0, 0))
-rho_vanilla = vmap(_rho_vanilla, in_axes=(0, 0, 0, 0, 0))
+
+def delta_vanilla(
+    spots: jax.Array,
+    strikes: jax.Array,
+    expires: jax.Array,
+    vols: jax.Array,
+    discount_rates: jax.Array,
+    are_calls: jax.Array = None,
+    dtype: jnp.dtype = None,
+) -> jax.Array:
+    """
+    Calculate the delta of a call/put option under the BS model (vectorized)
+
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates.
+    :param are_calls: (jax.Array): Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of delta of the given options.
+    """
+    return vmap(_delta_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
+        spots, strikes, expires, vols, discount_rates, are_calls, dtype
+    )
+
+
+def gamma_vanilla(
+    spots: jax.Array,
+    strikes: jax.Array,
+    expires: jax.Array,
+    vols: jax.Array,
+    discount_rates: jax.Array,
+    are_calls: jax.Array = None,
+    dtype: jnp.dtype = None,
+) -> jax.Array:
+    """
+    Calculate the gamma of a european option under the BS model (vectorized)
+
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates
+    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of gamma of the given options.
+    """
+    return vmap(_gamma_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
+        spots, strikes, expires, vols, discount_rates, are_calls, dtype
+    )
+
+
+def theta_vanilla(
+    spots: jax.Array,
+    strikes: jax.Array,
+    expires: jax.Array,
+    vols: jax.Array,
+    discount_rates: jax.Array,
+    are_calls: jax.Array = None,
+    dtype: jnp.dtype = None,
+) -> jax.Array:
+    """
+    Calculate the theta of a european option under the BS model (vectorized)
+
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates
+    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of theta of the given options.
+    """
+    return vmap(_theta_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
+        spots, strikes, expires, vols, discount_rates, are_calls, dtype
+    )
+
+
+def rho_vanilla(
+    spots: jax.Array,
+    strikes: jax.Array,
+    expires: jax.Array,
+    vols: jax.Array,
+    discount_rates: jax.Array,
+    are_calls: jax.Array = None,
+    dtype: jnp.dtype = None,
+) -> jax.Array:
+    """
+    Calculate the rho of a european option under the BS model (vectorized)
+
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates
+    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of rho of the given options.
+    """
+    return vmap(_rho_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
+        spots, strikes, expires, vols, discount_rates, are_calls, dtype
+    )
+
+
+def vega_vanilla(
+    spots: jax.Array,
+    strikes: jax.Array,
+    expires: jax.Array,
+    vols: jax.Array,
+    discount_rates: jax.Array,
+    are_calls: jax.Array = None,
+    dtype: jnp.dtype = None,
+) -> jax.Array:
+    """
+    Calculate the vega of a european option under the BS model (vectorized)
+
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates
+    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of vega of the given options.
+    """
+    return vmap(_vega_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
+        spots, strikes, expires, vols, discount_rates, are_calls, dtype
+    )

--- a/jaxfin/price_engine/black_scholes/vanilla_options.py
+++ b/jaxfin/price_engine/black_scholes/vanilla_options.py
@@ -4,7 +4,7 @@ Black Scholes prices for Vanilla European options
 import jax
 import jax.numpy as jnp
 
-from ..common import compute_undiscounted_call_prices
+from ..common import compute_discounted_call_prices
 from ..math import cum_normal, d1, density_normal
 from ..utils import cast_arrays
 
@@ -14,7 +14,7 @@ def bs_price(
     strikes: jax.Array,
     expires: jax.Array,
     vols: jax.Array,
-    discount_rates: jax.Array = None,
+    discount_rates: jax.Array,
     are_calls: jax.Array = None,
     dtype: jnp.dtype = None,
 ) -> jax.Array:
@@ -31,18 +31,13 @@ def bs_price(
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (jax.Array): Array of computed option prices.
     """
-    shape = spots.shape
-
     [spots, strikes, expires, vols] = cast_arrays(
         [spots, strikes, expires, vols], dtype
     )
 
-    if discount_rates is None:
-        discount_rates = jnp.zeros(shape, dtype=dtype)
+    discount_factors = jnp.exp(-discount_rates * expires)
 
-    discount_factors = jnp.exp(discount_rates * expires)
-
-    calls = compute_undiscounted_call_prices(
+    calls = compute_discounted_call_prices(
         spots, strikes, expires, vols, discount_rates
     )
 

--- a/jaxfin/price_engine/black_scholes/vanilla_options.py
+++ b/jaxfin/price_engine/black_scholes/vanilla_options.py
@@ -2,6 +2,7 @@
 Black Scholes prices for Vanilla European options
 """
 import jax
+from jax import grad
 import jax.numpy as jnp
 
 from ..common import compute_discounted_call_prices
@@ -53,33 +54,23 @@ def delta_vanilla(
     strikes: jax.Array,
     expires: jax.Array,
     vols: jax.Array,
-    discount_rates: jax.Array = None,
+    discount_rates: jax.Array,
     are_calls: jax.Array = None,
     dtype: jnp.dtype = None,
 ) -> jax.Array:
     """
-    Calculate the delta of a call/put option
+    Calculate the delta of a call/put option under the BS model
 
-    :param spots:
-    :param strikes:
-    :param expires:
-    :param vols:
-    :param discount_rates:
-    :param are_calls:
-    :param dtype:
-    :return:
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates.
+    :param are_calls: (jax.Array): Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of delta of the given options.
     """
-    [spots, strikes, expires, vols] = cast_arrays(
-        [spots, strikes, expires, vols], dtype
-    )
-
-    d1s = d1(spots, strikes, vols, expires, discount_rates)
-
-    return (
-        cum_normal(d1s)
-        if are_calls is None
-        else jnp.where(are_calls, cum_normal(d1s), cum_normal(d1s) - 1)
-    )
+    return grad(bs_price, argnums=0)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
 
 
 def gamma_vanilla(
@@ -87,24 +78,89 @@ def gamma_vanilla(
     strikes: jax.Array,
     expires: jax.Array,
     vols: jax.Array,
-    discount_rates: jax.Array = None,
+    discount_rates: jax.Array,
+    are_calls: jax.Array = None,
     dtype: jnp.dtype = None,
 ) -> jax.Array:
     """
-    Calculate the gamma of a european option
+    Calculate the gamma of a european option under the BS model
 
-    :param spots:
-    :param strikes:
-    :param expires:
-    :param vols:
-    :param discount_rates:
-    :param dtype:
-    :return:
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates
+    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of gamma of the given options.
     """
-    [spots, strikes, expires, vols] = cast_arrays(
-        [spots, strikes, expires, vols], dtype
-    )
+    return grad(grad(bs_price, argnums=0), argnums=0)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
 
-    d1s = d1(spots, strikes, vols, expires, discount_rates)
+def theta_vanilla(
+    spots: jax.Array,
+    strikes: jax.Array,
+    expires: jax.Array,
+    vols: jax.Array,
+    discount_rates: jax.Array,
+    are_calls: jax.Array = None,
+    dtype: jnp.dtype = None,
+) -> jax.Array:
+    """
+    Calculate the theta of a european option under the BS model
 
-    return density_normal(d1s) / (spots * vols * jnp.sqrt(expires))
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates
+    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of theta of the given options.
+    """
+    return grad(bs_price, argnums=2)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
+
+def vega_vanilla(
+    spots: jax.Array,
+    strikes: jax.Array,
+    expires: jax.Array,
+    vols: jax.Array,
+    discount_rates: jax.Array,
+    are_calls: jax.Array = None,
+    dtype: jnp.dtype = None,
+) -> jax.Array:
+    """
+    Calculate the vega of a european option under the BS model
+
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates
+    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of vega of the given options.
+    """
+    return grad(bs_price, argnums=3)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
+
+def rho_vanilla(
+    spots: jax.Array,
+    strikes: jax.Array,
+    expires: jax.Array,
+    vols: jax.Array,
+    discount_rates: jax.Array,
+    are_calls: jax.Array = None,
+    dtype: jnp.dtype = None,
+) -> jax.Array:
+    """
+    Calculate the rho of a european option under the BS model
+
+    :param spots: (jax.Array): Array of current asset prices.
+    :param strikes: (jax.Array): Array of option strike prices.
+    :param expires: (jax.Array): Array of option expiration times.
+    :param vols: (jax.Array): Array of option volatility values.
+    :param discount_rates: (jax.Array): Array of risk-free interest rates
+    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
+    :return: (jax.Array): Array of rho of the given options.
+    """
+    return grad(bs_price, argnums=4)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)

--- a/jaxfin/price_engine/black_scholes/vanilla_options.py
+++ b/jaxfin/price_engine/black_scholes/vanilla_options.py
@@ -2,7 +2,7 @@
 Black Scholes prices for Vanilla European options
 """
 import jax
-from jax import grad
+from jax import grad, vmap
 import jax.numpy as jnp
 
 from ..common import compute_discounted_call_prices
@@ -49,7 +49,7 @@ def bs_price(
     return jnp.where(are_calls, calls, puts)
 
 
-def delta_vanilla(
+def _delta_vanilla(
     spots: jax.Array,
     strikes: jax.Array,
     expires: jax.Array,
@@ -72,8 +72,7 @@ def delta_vanilla(
     """
     return grad(bs_price, argnums=0)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
 
-
-def gamma_vanilla(
+def _gamma_vanilla(
     spots: jax.Array,
     strikes: jax.Array,
     expires: jax.Array,
@@ -96,7 +95,7 @@ def gamma_vanilla(
     """
     return grad(grad(bs_price, argnums=0), argnums=0)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
 
-def theta_vanilla(
+def _theta_vanilla(
     spots: jax.Array,
     strikes: jax.Array,
     expires: jax.Array,
@@ -119,7 +118,7 @@ def theta_vanilla(
     """
     return grad(bs_price, argnums=2)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
 
-def vega_vanilla(
+def _vega_vanilla(
     spots: jax.Array,
     strikes: jax.Array,
     expires: jax.Array,
@@ -142,7 +141,7 @@ def vega_vanilla(
     """
     return grad(bs_price, argnums=3)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
 
-def rho_vanilla(
+def _rho_vanilla(
     spots: jax.Array,
     strikes: jax.Array,
     expires: jax.Array,
@@ -164,3 +163,11 @@ def rho_vanilla(
     :return: (jax.Array): Array of rho of the given options.
     """
     return grad(bs_price, argnums=4)(spots, strikes, expires, vols, discount_rates, are_calls, dtype)
+
+# Vectorize version of the functions since we are dealing with arrays
+
+delta_vanilla = vmap(_delta_vanilla, in_axes=(0, 0, 0, 0, 0))
+gamma_vanilla = vmap(_gamma_vanilla, in_axes=(0, 0, 0, 0, 0))
+theta_vanilla = vmap(_theta_vanilla, in_axes=(0, 0, 0, 0, 0))
+vega_vanilla = vmap(_vega_vanilla, in_axes=(0, 0, 0, 0, 0))
+rho_vanilla = vmap(_rho_vanilla, in_axes=(0, 0, 0, 0, 0))

--- a/jaxfin/price_engine/black_scholes/vanilla_options.py
+++ b/jaxfin/price_engine/black_scholes/vanilla_options.py
@@ -2,8 +2,8 @@
 Black Scholes prices for Vanilla European options
 """
 import jax
-from jax import grad, vmap
 import jax.numpy as jnp
+from jax import grad, vmap
 
 from ..common import compute_discounted_call_prices
 from ..utils import cast_arrays

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ exclude = ["examples*"]
 # Homepage = "https://github.com/pypa/sampleproject"
 # Issues = "https://github.com/pypa/sampleproject/issues"
 
+[tool.isort]
+profile = 'black'
+
 [tool.pylint.main]
 # Analyse import fallback blocks. This can be used to support both Python 2 and 3
 # compatible code, which means that the block might have code that exists only in

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -19,6 +19,7 @@ platformdirs==4.1.0
 pluggy==1.3.0
 pylint==3.0.3
 pytest==7.4.3
+pytest-cov==4.1.0
 pytest-html==4.1.1
 scipy==1.11.4
 setuptools-scm==8.0.4

--- a/scripts/get-tests-cov.bat
+++ b/scripts/get-tests-cov.bat
@@ -1,0 +1,7 @@
+@ECHO OFF
+
+call %~dp0configure-python.bat
+
+pytest --cov=jaxfin tests/ --cov-report=html
+
+pause

--- a/tests/price_engine/test_black.py
+++ b/tests/price_engine/test_black.py
@@ -11,8 +11,9 @@ def test_one_future_option():
     expire = jnp.array([1.0], dtype=DTYPE)
     vol = jnp.array([0.3], dtype=DTYPE)
     strike = jnp.array([110], dtype=DTYPE)
+    risk_free_rate = jnp.array([0.0], dtype=DTYPE)
 
-    price = future_option_price(spot, strike, expire, vol, dtype=DTYPE)
+    price = future_option_price(spot, strike, expire, vol, risk_free_rate, dtype=DTYPE)
 
     assert price[0] == 8.141014
 
@@ -22,8 +23,10 @@ def test_foption_batch_calls():
     expires = jnp.array([1.0, 1.0, 1.0, 1.0, 1.0], dtype=DTYPE)
     vols = jnp.array([.3, .25, .4, .2, .1], dtype=DTYPE)
     strikes = jnp.array([120, 120, 120, 120, 120], dtype=DTYPE)
+    discount_rates = jnp.array([0.00, 0.00, 0.00, 0.00, 0.00], dtype=DTYPE)
 
-    prices = future_option_price(spots, strikes, expires, vols, dtype=DTYPE)
+    prices = future_option_price(spots, strikes, expires, vols, discount_rates,
+                                  dtype=DTYPE)
     expected = jnp.array([5.440567, 1.602787, 3.140933, 5.010391, 4.7853127])
 
     assert jnp.isclose(prices, expected, atol=TOL).all()
@@ -35,8 +38,9 @@ def test_foption_batch_mixed():
     vols = jnp.array([.3, .25, .4, .2, .1], dtype=DTYPE)
     strikes = jnp.array([120, 75, 75, 120, 120], dtype=DTYPE)
     are_calls = jnp.array([True, False, False, True, True], dtype=jnp.bool_)
+    discount_rates = jnp.array([0.00, 0.00, 0.00, 0.00, 0.00], dtype=DTYPE)
 
-    prices = future_option_price(spots, strikes, expires, vols,
+    prices = future_option_price(spots, strikes, expires, vols, discount_rates,
                                  are_calls=are_calls, dtype=DTYPE)
     expected = jnp.array([5.440567, 2.7794075, 9.942638, 5.010391, 4.7853127])
 
@@ -53,6 +57,6 @@ def test_foption_batch_mixed_disc():
 
     prices = future_option_price(spots, strikes, expires, vols,
                                  are_calls=are_calls, discount_rates=discount_rates, dtype=DTYPE)
-    expected = jnp.array([5.8235464, 2.5895524, 9.5519285, 6.4302106, 8.570614])
+    expected = jnp.array([5.7082324, 2.5256162, 9.177393, 6.055744, 7.7550125])
 
     assert jnp.isclose(prices, expected, atol=TOL).all()

--- a/tests/price_engine/test_black.py
+++ b/tests/price_engine/test_black.py
@@ -1,6 +1,8 @@
 import jax.numpy as jnp
 
-from jaxfin.price_engine.black import future_option_price
+import pytest
+
+from jaxfin.price_engine.black import future_option_price, future_option_delta, future_option_gamma
 
 TOL = 1e-3
 DTYPE = jnp.float32
@@ -60,3 +62,52 @@ def test_foption_batch_mixed_disc():
     expected = jnp.array([5.7082324, 2.5256162, 9.177393, 6.055744, 7.7550125])
 
     assert jnp.isclose(prices, expected, atol=TOL).all()
+
+@pytest.mark.parametrize("spot, strike, expire, vol, rate, e_call_delta, e_put_delta",
+                         [(100, 120, 1, 0.3, 0.0, 0.32357, -0.67643),
+                          (100, 110, 1, 0.3, 0.0, 0.43341, -0.56659),
+                          (100, 120, 1, 0.2, 0.05, 0.30971, -0.71975),
+                          (80, 150, 0.5, 0.5, 0.02, 0.05894, -0.94222),
+                          (170, 160, 0.25, 0.15, 0.01, 0.81452, -0.18953)
+                        ])
+class TestDelta:
+
+    def test_delta_bs(self, spot, strike, expire, vol, rate, e_call_delta, e_put_delta):
+        spot = jnp.array([spot], dtype=DTYPE)
+        strike = jnp.array([strike], dtype=DTYPE)
+        expire = jnp.array([expire], dtype=DTYPE)
+        vol = jnp.array([vol], dtype=DTYPE)
+        rate = jnp.array([rate], dtype=DTYPE)
+        dividends = jnp.array([0.0], dtype=DTYPE)
+        put_flag = jnp.array([False], dtype=jnp.bool_)
+        e_call_delta = jnp.array([e_call_delta], dtype=DTYPE)
+        call_delta = future_option_delta(spot, strike, expire, vol, rate, dividends)
+        put_delta = future_option_delta(spot, strike, expire, vol, rate, dividends, are_calls=put_flag)
+
+        assert jnp.isclose(call_delta, e_call_delta, atol=TOL).all()
+        assert jnp.isclose(put_delta, e_put_delta, atol=TOL).all()
+
+
+@pytest.mark.parametrize("spot, strike, expire, vol, rate, expected_gamma",
+                            [(100, 120, 1, 0.3, 0.0, 0.01197),
+                            (100, 110, 1, 0.3, 0.0, 0.013112),
+                            (100, 120, 1, 0.2, 0.01, 0.01523321),
+                            (80, 150, 0.5, 0.5, 0.02, 0.00417),
+                            (170, 160, 0.25, 0.15, 0.01, 0.02136)
+                            ])
+class TestGamma:
+
+    def test_gamma_bs(self, spot, strike, expire, vol, rate, expected_gamma):
+        spot = jnp.array([spot], dtype=DTYPE)
+        strike = jnp.array([strike], dtype=DTYPE)
+        expire = jnp.array([expire], dtype=DTYPE)
+        vol = jnp.array([vol], dtype=DTYPE)
+        rate = jnp.array([rate], dtype=DTYPE)
+        dividends = jnp.array([0.0], dtype=DTYPE)
+        put_flag = jnp.array([False], dtype=jnp.bool_)
+        expected_gamma = jnp.array([expected_gamma], dtype=DTYPE)
+        call_gamma = future_option_gamma(spot, strike, expire, vol, rate, dividends)
+        put_gamma = future_option_gamma(spot, strike, expire, vol, rate, dividends, are_calls=put_flag)
+
+        assert jnp.isclose(call_gamma, expected_gamma, atol=TOL).all()
+        assert jnp.isclose(put_gamma, call_gamma, atol=TOL).all()

--- a/tests/price_engine/test_bs.py
+++ b/tests/price_engine/test_bs.py
@@ -144,9 +144,14 @@ class TestTheta:
         expire = jnp.array([expire], dtype=DTYPE)
         vol = jnp.array([vol], dtype=DTYPE)
         rate = jnp.array([rate], dtype=DTYPE)
+        put_flag = jnp.array([False], dtype=jnp.bool_)
+        e_call_theta = jnp.array([e_call_theta], dtype=DTYPE)
+        e_put_theta = jnp.array([e_put_theta], dtype=DTYPE)
         theta = theta_european(spot, strike, expire, vol, rate)
+        p_theta = theta_european(spot, strike, expire, vol, rate, are_calls=put_flag)
 
         assert jnp.isclose(theta, e_call_theta, atol=TOL).all()
+        assert jnp.isclose(p_theta, e_put_theta, atol=TOL).all()
 
 @pytest.mark.parametrize("spot, strike, expire, vol, rate, e_call_rho, e_put_rho",
                             [(100, 120, 1, 0.3, 0.0, 26.91644, -93.08356),

--- a/tests/price_engine/test_bs.py
+++ b/tests/price_engine/test_bs.py
@@ -1,5 +1,4 @@
 import jax.numpy as jnp
-from jax import vmap
 
 from jaxfin.price_engine.black_scholes import european_price, delta_european, gamma_european, theta_european, rho_european, vega_european
 
@@ -89,3 +88,83 @@ class TestDelta:
         assert jnp.isclose(call_delta, e_call_delta, atol=TOL).all()
         assert jnp.isclose(put_delta, e_put_delta, atol=TOL).all()
         assert jnp.isclose(call_delta - 1.0, put_delta, atol=TOL).all()
+
+@pytest.mark.parametrize("spot, strike, expire, vol, rate, expected_gamma",
+                            [(100, 120, 1, 0.3, 0.0, 0.01198),
+                            (100, 110, 1, 0.3, 0.0, 0.01311),
+                            (100, 120, 1, 0.2, 0.05, 0.01704),
+                            (80, 150, 0.5, 0.5, 0.02, 0.00409),
+                            (170, 160, 0.25, 0.15, 0.01, 0.02126)
+                            ])
+class TestGamma:
+
+    def test_gamma_bs(self, spot, strike, expire, vol, rate, expected_gamma):
+        spot = jnp.array([spot], dtype=DTYPE)
+        strike = jnp.array([strike], dtype=DTYPE)
+        expire = jnp.array([expire], dtype=DTYPE)
+        vol = jnp.array([vol], dtype=DTYPE)
+        rate = jnp.array([rate], dtype=DTYPE)
+        gamma = gamma_european(spot, strike, expire, vol, rate)
+
+        assert jnp.isclose(gamma, expected_gamma, atol=TOL).all()
+
+@pytest.mark.parametrize("spot, strike, expire, vol, rate, e_call_theta, e_put_theta",
+                            [(100, 120, 1, 0.3, 0.0, 5.38894, 5.38894),
+                            (100, 110, 1, 0.3, 0.0, 5.90058, 5.90058),
+                            (100, 120, 1, 0.2, 0.05, 4.68097, -1.02641),
+                            (80, 150, 0.5, 0.5, 0.02, 3.35533, 0.38519),
+                            (170, 160, 0.25, 0.15, 0.01, 8.17193, 6.57593)
+                            ])
+class TestTheta:
+
+    def test_theta_bs(self, spot, strike, expire, vol, rate, e_call_theta, e_put_theta):
+        spot = jnp.array([spot], dtype=DTYPE)
+        strike = jnp.array([strike], dtype=DTYPE)
+        expire = jnp.array([expire], dtype=DTYPE)
+        vol = jnp.array([vol], dtype=DTYPE)
+        rate = jnp.array([rate], dtype=DTYPE)
+        theta = theta_european(spot, strike, expire, vol, rate)
+
+        assert jnp.isclose(theta, e_call_theta, atol=TOL).all()
+
+@pytest.mark.parametrize("spot, strike, expire, vol, rate, e_call_rho, e_put_rho",
+                            [(100, 120, 1, 0.3, 0.0, 26.91644, -93.08356),
+                            (100, 110, 1, 0.3, 0.0, 35.19993, -74.80007),
+                            (100, 120, 1, 0.2, 0.05, 25.47168, -88.67585),
+                            (80, 150, 0.5, 0.5, 0.02, 2.00656, -72.24718),
+                            (170, 160, 0.25, 0.15, 0.01, 31.49509, -8.40503)
+                            ]) 
+class TestRho:
+
+    def test_rho_bs(self, spot, strike, expire, vol, rate, e_call_rho, e_put_rho):
+        spot = jnp.array([spot], dtype=DTYPE)
+        strike = jnp.array([strike], dtype=DTYPE)
+        expire = jnp.array([expire], dtype=DTYPE)
+        vol = jnp.array([vol], dtype=DTYPE)
+        rate = jnp.array([rate], dtype=DTYPE)
+        put_flag = jnp.array([False], dtype=jnp.bool_)
+        e_call_rho = jnp.array([e_call_rho], dtype=DTYPE)
+        call_rho = rho_european(spot, strike, expire, vol, rate)
+        put_rho = rho_european(spot, strike, expire, vol, rate, are_calls=put_flag)
+
+        assert jnp.isclose(call_rho, e_call_rho, atol=TOL).all()
+        assert jnp.isclose(put_rho, e_put_rho, atol=TOL).all()
+
+@pytest.mark.parametrize("spot, strike, expire, vol, rate, expected_vega",
+                            [(100, 120, 1, 0.3, 0.0, 35.92629),
+                            (100, 110, 1, 0.3, 0.0, 39.33717),
+                            (100, 120, 1, 0.2, 0.05, 34.07384),
+                            (80, 150, 0.5, 0.5, 0.02, 6.55014),
+                            (170, 160, 0.25, 0.15, 0.01, 23.04042)
+                            ])
+class TestVega:
+    
+        def test_vega_bs(self, spot, strike, expire, vol, rate, expected_vega):
+            spot = jnp.array([spot], dtype=DTYPE)
+            strike = jnp.array([strike], dtype=DTYPE)
+            expire = jnp.array([expire], dtype=DTYPE)
+            vol = jnp.array([vol], dtype=DTYPE)
+            rate = jnp.array([rate], dtype=DTYPE)
+            vega = vega_european(spot, strike, expire, vol, rate)
+    
+            assert jnp.isclose(vega, expected_vega, atol=TOL).all()

--- a/tests/price_engine/test_bs.py
+++ b/tests/price_engine/test_bs.py
@@ -1,6 +1,9 @@
 import jax.numpy as jnp
+from jax import vmap
 
-from jaxfin.price_engine.black_scholes import european_price
+from jaxfin.price_engine.black_scholes import european_price, delta_european, gamma_european, theta_european, rho_european, vega_european
+
+import pytest
 
 TOL = 1e-3
 DTYPE = jnp.float32
@@ -60,3 +63,29 @@ def test_vanilla_batch_mixed_disc():
     expected = jnp.array([5.714386,  2.5328674, 9.19194, 6.155064, 8.165947])
 
     assert jnp.isclose(prices, expected, atol=TOL).all()
+
+### Test Greeks Calculations ###
+
+@pytest.mark.parametrize("spot, strike, expire, vol, rate, e_call_delta, e_put_delta",
+                         [(100, 120, 1, 0.3, 0.0, 0.32357, -0.67643),
+                          (100, 110, 1, 0.3, 0.0, 0.43341, -0.56659),
+                          (100, 120, 1, 0.2, 0.05, 0.28719, -0.71281),
+                          (80, 150, 0.5, 0.5, 0.02, 0.05787, -0.94213),
+                          (170, 160, 0.25, 0.15, 0.01, 0.81034, -0.18966)
+                        ])
+class TestDelta:
+
+    def test_delta_bs(self, spot, strike, expire, vol, rate, e_call_delta, e_put_delta):
+        spot = jnp.array([spot], dtype=DTYPE)
+        strike = jnp.array([strike], dtype=DTYPE)
+        expire = jnp.array([expire], dtype=DTYPE)
+        vol = jnp.array([vol], dtype=DTYPE)
+        rate = jnp.array([rate], dtype=DTYPE)
+        put_flag = jnp.array([False], dtype=jnp.bool_)
+        e_call_delta = jnp.array([e_call_delta], dtype=DTYPE)
+        call_delta = delta_european(spot, strike, expire, vol, rate)
+        put_delta = delta_european(spot, strike, expire, vol, rate, are_calls=put_flag)
+
+        assert jnp.isclose(call_delta, e_call_delta, atol=TOL).all()
+        assert jnp.isclose(put_delta, e_put_delta, atol=TOL).all()
+        assert jnp.isclose(call_delta - 1.0, put_delta, atol=TOL).all()

--- a/tests/price_engine/test_bs.py
+++ b/tests/price_engine/test_bs.py
@@ -89,6 +89,27 @@ class TestDelta:
         assert jnp.isclose(put_delta, e_put_delta, atol=TOL).all()
         assert jnp.isclose(call_delta - 1.0, put_delta, atol=TOL).all()
 
+
+class TestDeltaBatch:
+
+    def test_delta_bs_batch(self):
+        spots = jnp.array([100, 90, 80, 110, 120], dtype=DTYPE)
+        expires = jnp.array([1.0, 1.0, 1.0, 1.0, 1.0], dtype=DTYPE)
+        vols = jnp.array([.3, .25, .4, .2, .1], dtype=DTYPE)
+        strikes = jnp.array([120, 120, 120, 120, 120], dtype=DTYPE)
+        discount_rates = jnp.array([0.00, 0.00, 0.00, 0.00, 0.00], dtype=DTYPE)
+
+        call_delta = delta_european(spots, strikes, expires, vols, discount_rates)
+        put_flag = jnp.array([False, False, False, False, False], dtype=jnp.bool_)
+        put_delta = delta_european(spots, strikes, expires, vols, discount_rates, are_calls=put_flag)
+
+        expected_call = jnp.array([0.323570, 0.152509, 0.207919, 0.36879, 0.51993])
+        expected_put = jnp.array([-0.676429, -0.847490, -0.79208, -0.63120, -0.480061])
+
+        assert jnp.isclose(call_delta, expected_call, atol=TOL).all()
+        assert jnp.isclose(put_delta, expected_put, atol=TOL).all()
+        assert jnp.isclose(call_delta - 1.0, put_delta, atol=TOL).all()
+
 @pytest.mark.parametrize("spot, strike, expire, vol, rate, expected_gamma",
                             [(100, 120, 1, 0.3, 0.0, 0.01198),
                             (100, 110, 1, 0.3, 0.0, 0.01311),

--- a/tests/price_engine/test_bs.py
+++ b/tests/price_engine/test_bs.py
@@ -12,8 +12,9 @@ def test_one_vanilla():
     expire = jnp.array([1.0], dtype=dtype)
     vol = jnp.array([0.3], dtype=dtype)
     strike = jnp.array([110], dtype=dtype)
+    risk_free_rate = jnp.array([0.0], dtype=dtype)
 
-    price = european_price(spot, strike, expire, vol, dtype=dtype)
+    price = european_price(spot, strike, expire, vol, risk_free_rate, dtype=dtype)
 
     assert price[0] == 8.141014
 
@@ -23,8 +24,9 @@ def test_vanilla_batch_calls():
     expires = jnp.array([1.0, 1.0, 1.0, 1.0, 1.0], dtype=DTYPE)
     vols = jnp.array([.3, .25, .4, .2, .1], dtype=DTYPE)
     strikes = jnp.array([120, 120, 120, 120, 120], dtype=DTYPE)
+    discount_rates = jnp.array([0.00, 0.00, 0.00, 0.00, 0.00], dtype=DTYPE)
 
-    prices = european_price(spots, strikes, expires, vols, dtype=DTYPE)
+    prices = european_price(spots, strikes, expires, vols, discount_rates, dtype=DTYPE)
     expected = jnp.array([5.440567, 1.602787, 3.140933, 5.010391, 4.7853127])
 
     assert jnp.isclose(prices, expected, atol=TOL).all()
@@ -36,8 +38,9 @@ def test_vanilla_batch_mixed():
     vols = jnp.array([.3, .25, .4, .2, .1], dtype=DTYPE)
     strikes = jnp.array([120, 75, 75, 120, 120], dtype=DTYPE)
     are_calls = jnp.array([True, False, False, True, True], dtype=jnp.bool_)
+    discount_rates = jnp.array([0.00, 0.00, 0.00, 0.00, 0.00], dtype=DTYPE)
 
-    prices = european_price(spots, strikes, expires, vols,
+    prices = european_price(spots, strikes, expires, vols, discount_rates,
                             are_calls=are_calls, dtype=DTYPE)
     expected = jnp.array([5.440567, 2.7794075, 9.942638, 5.010391, 4.7853127])
 
@@ -54,6 +57,6 @@ def test_vanilla_batch_mixed_disc():
 
     prices = european_price(spots, strikes, expires, vols,
                             are_calls=are_calls, discount_rates=discount_rates, dtype=DTYPE)
-    expected = jnp.array([5.434498, 3.7151947, 11.442871, 4.9134297, 4.2234654])
+    expected = jnp.array([5.714386,  2.5328674, 9.19194, 6.155064, 8.165947])
 
     assert jnp.isclose(prices, expected, atol=TOL).all()


### PR DESCRIPTION
- Used `jax.grad` to compute the Greeks, to make the code more readable and intuitive. 
- The precision between the closed formula and the auto-diff computation was minimal (10e-7).
- Added the most important greeks for the BS (delta, gamma, rho, theta, vega)
- Added just delta and gamma calculation for the Black model.