### PR TITLE
7 bugfix review on how vmap is used in the greeks calculations

### DIFF
--- a/jaxfin/price_engine/black/black_model.py
+++ b/jaxfin/price_engine/black/black_model.py
@@ -1,6 +1,8 @@
 """
 Black '76 prices for options on forwards and futures
 """
+from typing import Union
+
 import jax
 import jax.numpy as jnp
 from jax import grad, vmap
@@ -115,56 +117,96 @@ def _gamma_black(
 
 
 def delta_black(
-    spots: jax.Array,
-    strikes: jax.Array,
-    expires: jax.Array,
-    vols: jax.Array,
-    discount_rates: jax.Array,
-    dividend_rates: jax.Array = None,
-    are_calls: jax.Array = None,
+    spots: Union[jax.Array, float],
+    strikes: Union[jax.Array, float],
+    expires: Union[jax.Array, float],
+    vols: Union[jax.Array, float],
+    discount_rates: Union[jax.Array, float],
+    dividend_rates: Union[jax.Array, float] = None,
+    are_calls: Union[jax.Array, bool] = None,
     dtype: jnp.dtype = None,
-) -> jax.Array:
+) -> Union[jax.Array, float]:
     """
     Compute the option deltas for european options using the Black '76 model. (vectorized)
 
-    :param spots: (jax.Array): Array of current asset prices.
-    :param strikes: (jax.Array): Array of option strike prices.
-    :param expires: (jax.Array): Array of option expiration times.
-    :param vols: (jax.Array): Array of option volatility values.
-    :param discount_rates: (jax.Array): Array of risk-free interest rates. Defaults to None.
-    :param dividend_rates: (jax.Array): Array of dividend rates. Defaults to None.
-    :param are_calls: (jax.Array): Array of booleans indicating whether options are calls (True) or puts (False).
+    :param spots: (Union[jax.Array, float]): Current asset price or array of prices.
+    :param strikes: (Union[jax.Array, float]): Option strike price or array of prices.
+    :param expires: (Union[jax.Array, float]): Option expiration time or array of times.
+    :param vols: (Union[jax.Array, float]): Option volatility value or array of values.
+    :param discount_rates: (Union[jax.Array, float]): Risk-free interest rate or array of rates.
+    :param dividend_rates: (Union[jax.Array, float]): Dividend rate or array of rates. Defaults to None.
+    :param are_calls: (Union[jax.Array, bool]): Boolean indicating whether option is a 
+                                                call or put, or array of booleans.
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
-    :return: (jax.Array): Array of computed option deltas.
+    :return: (Union[jax.Array, float]): Delta of the given option or array of deltas.
     """
+    if jnp.isscalar(spots) or spots.shape == ():
+        return _delta_black(
+            spots,
+            strikes,
+            expires,
+            vols,
+            discount_rates,
+            dividend_rates,
+            are_calls,
+            dtype,
+        )
+
     return vmap(_delta_black, in_axes=(0, 0, 0, 0, 0, 0, 0, None))(
-        spots, strikes, expires, vols, discount_rates, dividend_rates, are_calls, dtype
+        spots,
+        strikes,
+        expires,
+        vols,
+        discount_rates,
+        dividend_rates,
+        are_calls,
+        dtype,
     )
 
 
 def gamma_black(
-    spots: jax.Array,
-    strikes: jax.Array,
-    expires: jax.Array,
-    vols: jax.Array,
-    discount_rates: jax.Array,
-    dividend_rates: jax.Array = None,
-    are_calls: jax.Array = None,
+    spots: Union[jax.Array, float],
+    strikes: Union[jax.Array, float],
+    expires: Union[jax.Array, float],
+    vols: Union[jax.Array, float],
+    discount_rates: Union[jax.Array, float],
+    dividend_rates: Union[jax.Array, float] = None,
+    are_calls: Union[jax.Array, bool] = None,
     dtype: jnp.dtype = None,
-) -> jax.Array:
+) -> Union[jax.Array, float]:
     """
     Compute the option gammas for european options using the Black '76 model. (vectorized)
 
-    :param spots: (jax.Array): Array of current asset prices.
-    :param strikes: (jax.Array): Array of option strike prices.
-    :param expires: (jax.Array): Array of option expiration times.
-    :param vols: (jax.Array): Array of option volatility values.
-    :param discount_rates: (jax.Array): Array of risk-free interest rates. Defaults to None.
-    :param dividend_rates: (jax.Array): Array of dividend rates. Defaults to None.
-    :param are_calls: (jax.Array): Array of booleans indicating whether options are calls (True) or puts (False).
+    :param spots: (Union[jax.Array, float]): Current asset price or array of prices.
+    :param strikes: (Union[jax.Array, float]): Option strike price or array of prices.
+    :param expires: (Union[jax.Array, float]): Option expiration time or array of times.
+    :param vols: (Union[jax.Array, float]): Option volatility value or array of values.
+    :param discount_rates: (Union[jax.Array, float]): Risk-free interest rate or array of rates.
+    :param dividend_rates: (Union[jax.Array, float]): Dividend rate or array of rates. Defaults to None.
+    :param are_calls: (Union[jax.Array, bool]): Boolean indicating whether option is a 
+                                                call or put, or array of booleans.
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
-    :return: (jax.Array): Array of computed option gammas.
+    :return: (Union[jax.Array, float]): Gamma of the given option or array of gammas.
     """
+    if jnp.isscalar(spots) or spots.shape == ():
+        return _gamma_black(
+            spots,
+            strikes,
+            expires,
+            vols,
+            discount_rates,
+            dividend_rates,
+            are_calls,
+            dtype,
+        )
+
     return vmap(_gamma_black, in_axes=(0, 0, 0, 0, 0, 0, 0, None))(
-        spots, strikes, expires, vols, discount_rates, dividend_rates, are_calls, dtype
+        spots,
+        strikes,
+        expires,
+        vols,
+        discount_rates,
+        dividend_rates,
+        are_calls,
+        dtype,
     )

--- a/jaxfin/price_engine/black/black_model.py
+++ b/jaxfin/price_engine/black/black_model.py
@@ -5,7 +5,7 @@ from typing import Union
 
 import jax
 import jax.numpy as jnp
-from jax import grad, vmap
+from jax import grad, jit, vmap
 
 from ..common import compute_undiscounted_call_prices
 from ..utils import cast_arrays
@@ -60,6 +60,7 @@ def black_price(
     )
 
 
+@jit
 def _delta_black(
     spots: jax.Array,
     strikes: jax.Array,
@@ -88,6 +89,7 @@ def _delta_black(
     )
 
 
+@jit
 def _gamma_black(
     spots: jax.Array,
     strikes: jax.Array,
@@ -135,7 +137,7 @@ def delta_black(
     :param vols: (Union[jax.Array, float]): Option volatility value or array of values.
     :param discount_rates: (Union[jax.Array, float]): Risk-free interest rate or array of rates.
     :param dividend_rates: (Union[jax.Array, float]): Dividend rate or array of rates. Defaults to None.
-    :param are_calls: (Union[jax.Array, bool]): Boolean indicating whether option is a 
+    :param are_calls: (Union[jax.Array, bool]): Boolean indicating whether option is a
                                                 call or put, or array of booleans.
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (Union[jax.Array, float]): Delta of the given option or array of deltas.
@@ -152,7 +154,7 @@ def delta_black(
             dtype,
         )
 
-    return vmap(_delta_black, in_axes=(0, 0, 0, 0, 0, 0, 0, None))(
+    return jit(vmap(_delta_black, in_axes=(0, 0, 0, 0, 0, 0, 0, None)))(
         spots,
         strikes,
         expires,
@@ -183,7 +185,7 @@ def gamma_black(
     :param vols: (Union[jax.Array, float]): Option volatility value or array of values.
     :param discount_rates: (Union[jax.Array, float]): Risk-free interest rate or array of rates.
     :param dividend_rates: (Union[jax.Array, float]): Dividend rate or array of rates. Defaults to None.
-    :param are_calls: (Union[jax.Array, bool]): Boolean indicating whether option is a 
+    :param are_calls: (Union[jax.Array, bool]): Boolean indicating whether option is a
                                                 call or put, or array of booleans.
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (Union[jax.Array, float]): Gamma of the given option or array of gammas.
@@ -200,7 +202,7 @@ def gamma_black(
             dtype,
         )
 
-    return vmap(_gamma_black, in_axes=(0, 0, 0, 0, 0, 0, 0, None))(
+    return jit(vmap(_gamma_black, in_axes=(0, 0, 0, 0, 0, 0, 0, None)))(
         spots,
         strikes,
         expires,

--- a/jaxfin/price_engine/black_scholes/vanilla_options.py
+++ b/jaxfin/price_engine/black_scholes/vanilla_options.py
@@ -5,7 +5,7 @@ from typing import Union
 
 import jax
 import jax.numpy as jnp
-from jax import grad, vmap
+from jax import grad, jit, vmap
 
 from ..common import compute_discounted_call_prices
 from ..utils import cast_arrays
@@ -50,6 +50,7 @@ def bs_price(
     return jnp.where(are_calls, calls, puts)
 
 
+@jit
 def _delta_vanilla(
     spots: jax.Array,
     strikes: jax.Array,
@@ -77,6 +78,7 @@ def _delta_vanilla(
     )
 
 
+@jit
 def _gamma_vanilla(
     spots: jax.Array,
     strikes: jax.Array,
@@ -104,6 +106,7 @@ def _gamma_vanilla(
     )
 
 
+@jit
 def _theta_vanilla(
     spots: jax.Array,
     strikes: jax.Array,
@@ -131,6 +134,7 @@ def _theta_vanilla(
     )
 
 
+@jit
 def _vega_vanilla(
     spots: jax.Array,
     strikes: jax.Array,
@@ -158,6 +162,7 @@ def _vega_vanilla(
     )
 
 
+@jit
 def _rho_vanilla(
     spots: jax.Array,
     strikes: jax.Array,
@@ -215,7 +220,7 @@ def delta_vanilla(
             spots, strikes, expires, vols, discount_rates, are_calls, dtype
         )
 
-    return vmap(_delta_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
+    return jit(vmap(_delta_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None)))(
         spots, strikes, expires, vols, discount_rates, are_calls, dtype
     )
 
@@ -247,7 +252,7 @@ def gamma_vanilla(
             spots, strikes, expires, vols, discount_rates, are_calls, dtype
         )
 
-    return vmap(_gamma_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
+    return jit(vmap(_gamma_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None)))(
         spots, strikes, expires, vols, discount_rates, are_calls, dtype
     )
 
@@ -279,7 +284,7 @@ def theta_vanilla(
             spots, strikes, expires, vols, discount_rates, are_calls, dtype
         )
 
-    return vmap(_theta_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
+    return jit(vmap(_theta_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None)))(
         spots, strikes, expires, vols, discount_rates, are_calls, dtype
     )
 
@@ -311,7 +316,7 @@ def rho_vanilla(
             spots, strikes, expires, vols, discount_rates, are_calls, dtype
         )
 
-    return vmap(_rho_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
+    return jit(vmap(_rho_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None)))(
         spots, strikes, expires, vols, discount_rates, are_calls, dtype
     )
 
@@ -343,6 +348,6 @@ def vega_vanilla(
             spots, strikes, expires, vols, discount_rates, are_calls, dtype
         )
 
-    return vmap(_vega_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
+    return jit(vmap(_vega_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None)))(
         spots, strikes, expires, vols, discount_rates, are_calls, dtype
     )

--- a/jaxfin/price_engine/black_scholes/vanilla_options.py
+++ b/jaxfin/price_engine/black_scholes/vanilla_options.py
@@ -1,6 +1,8 @@
 """
 Black Scholes prices for Vanilla European options
 """
+from typing import Union
+
 import jax
 import jax.numpy as jnp
 from jax import grad, vmap
@@ -65,7 +67,8 @@ def _delta_vanilla(
     :param expires: (jax.Array): Array of option expiration times.
     :param vols: (jax.Array): Array of option volatility values.
     :param discount_rates: (jax.Array): Array of risk-free interest rates.
-    :param are_calls: (jax.Array): Array of booleans indicating whether options are calls (True) or puts (False).
+    :param are_calls: (jax.Array): Array of booleans indicating whether options
+                                   are calls (True) or puts (False).
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (jax.Array): Array of delta of the given options.
     """
@@ -91,7 +94,8 @@ def _gamma_vanilla(
     :param expires: (jax.Array): Array of option expiration times.
     :param vols: (jax.Array): Array of option volatility values.
     :param discount_rates: (jax.Array): Array of risk-free interest rates
-    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param are_calls: (jax.Array) Array of booleans indicating whether options
+                                  are calls (True) or puts (False).
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (jax.Array): Array of gamma of the given options.
     """
@@ -117,7 +121,8 @@ def _theta_vanilla(
     :param expires: (jax.Array): Array of option expiration times.
     :param vols: (jax.Array): Array of option volatility values.
     :param discount_rates: (jax.Array): Array of risk-free interest rates
-    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param are_calls: (jax.Array) Array of booleans indicating whether options
+                                  are calls (True) or puts (False).
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (jax.Array): Array of theta of the given options.
     """
@@ -143,7 +148,8 @@ def _vega_vanilla(
     :param expires: (jax.Array): Array of option expiration times.
     :param vols: (jax.Array): Array of option volatility values.
     :param discount_rates: (jax.Array): Array of risk-free interest rates
-    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param are_calls: (jax.Array) Array of booleans indicating whether options
+                                  are calls (True) or puts (False).
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (jax.Array): Array of vega of the given options.
     """
@@ -169,7 +175,8 @@ def _rho_vanilla(
     :param expires: (jax.Array): Array of option expiration times.
     :param vols: (jax.Array): Array of option volatility values.
     :param discount_rates: (jax.Array): Array of risk-free interest rates
-    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param are_calls: (jax.Array) Array of booleans indicating whether options
+                                  are calls (True) or puts (False).
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
     :return: (jax.Array): Array of rho of the given options.
     """
@@ -182,130 +189,160 @@ def _rho_vanilla(
 
 
 def delta_vanilla(
-    spots: jax.Array,
-    strikes: jax.Array,
-    expires: jax.Array,
-    vols: jax.Array,
-    discount_rates: jax.Array,
-    are_calls: jax.Array = None,
+    spots: Union[jax.Array, float],
+    strikes: Union[jax.Array, float],
+    expires: Union[jax.Array, float],
+    vols: Union[jax.Array, float],
+    discount_rates: Union[jax.Array, float],
+    are_calls: Union[jax.Array, bool] = None,
     dtype: jnp.dtype = None,
-) -> jax.Array:
+) -> Union[jax.Array, float]:
     """
     Calculate the delta of a call/put option under the BS model (vectorized)
 
-    :param spots: (jax.Array): Array of current asset prices.
-    :param strikes: (jax.Array): Array of option strike prices.
-    :param expires: (jax.Array): Array of option expiration times.
-    :param vols: (jax.Array): Array of option volatility values.
-    :param discount_rates: (jax.Array): Array of risk-free interest rates.
-    :param are_calls: (jax.Array): Array of booleans indicating whether options are calls (True) or puts (False).
+    :param spots: (Union[jax.Array, float]): Current asset price or array of prices.
+    :param strikes: (Union[jax.Array, float]): Option strike price or array of prices.
+    :param expires: (Union[jax.Array, float]): Option expiration time or array of times.
+    :param vols: (Union[jax.Array, float]): Option volatility value or array of values.
+    :param discount_rates: (Union[jax.Array, float]): Risk-free interest rate or array of rates.
+    :param are_calls: (Union[jax.Array, bool]): Boolean indicating whether option is a call or
+                                                put, or array of booleans.
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
-    :return: (jax.Array): Array of delta of the given options.
+    :return: (Union[jax.Array, float]): Delta of the given option or array of deltas.
     """
+    if jnp.isscalar(spots) or spots.shape == ():
+        return _delta_vanilla(
+            spots, strikes, expires, vols, discount_rates, are_calls, dtype
+        )
+
     return vmap(_delta_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
         spots, strikes, expires, vols, discount_rates, are_calls, dtype
     )
 
 
 def gamma_vanilla(
-    spots: jax.Array,
-    strikes: jax.Array,
-    expires: jax.Array,
-    vols: jax.Array,
-    discount_rates: jax.Array,
-    are_calls: jax.Array = None,
+    spots: Union[jax.Array, float],
+    strikes: Union[jax.Array, float],
+    expires: Union[jax.Array, float],
+    vols: Union[jax.Array, float],
+    discount_rates: Union[jax.Array, float],
+    are_calls: Union[jax.Array, bool] = None,
     dtype: jnp.dtype = None,
-) -> jax.Array:
+) -> Union[jax.Array, float]:
     """
     Calculate the gamma of a european option under the BS model (vectorized)
 
-    :param spots: (jax.Array): Array of current asset prices.
-    :param strikes: (jax.Array): Array of option strike prices.
-    :param expires: (jax.Array): Array of option expiration times.
-    :param vols: (jax.Array): Array of option volatility values.
-    :param discount_rates: (jax.Array): Array of risk-free interest rates
-    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param spots: (Union[jax.Array, float]): Current asset price or array of prices.
+    :param strikes: (Union[jax.Array, float]): Option strike price or array of prices.
+    :param expires: (Union[jax.Array, float]): Option expiration time or array of times.
+    :param vols: (Union[jax.Array, float]): Option volatility value or array of values.
+    :param discount_rates: (Union[jax.Array, float]): Risk-free interest rate or array of rates.
+    :param are_calls: (Union[jax.Array, bool]): Boolean indicating whether option is a
+                                                call or put, or array of booleans.
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
-    :return: (jax.Array): Array of gamma of the given options.
+    :return: (Union[jax.Array, float]): Gamma of the given option or array of gammas.
     """
+    if jnp.isscalar(spots) or spots.shape == ():
+        return _gamma_vanilla(
+            spots, strikes, expires, vols, discount_rates, are_calls, dtype
+        )
+
     return vmap(_gamma_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
         spots, strikes, expires, vols, discount_rates, are_calls, dtype
     )
 
 
 def theta_vanilla(
-    spots: jax.Array,
-    strikes: jax.Array,
-    expires: jax.Array,
-    vols: jax.Array,
-    discount_rates: jax.Array,
-    are_calls: jax.Array = None,
+    spots: Union[jax.Array, float],
+    strikes: Union[jax.Array, float],
+    expires: Union[jax.Array, float],
+    vols: Union[jax.Array, float],
+    discount_rates: Union[jax.Array, float],
+    are_calls: Union[jax.Array, bool] = None,
     dtype: jnp.dtype = None,
-) -> jax.Array:
+) -> Union[jax.Array, float]:
     """
     Calculate the theta of a european option under the BS model (vectorized)
 
-    :param spots: (jax.Array): Array of current asset prices.
-    :param strikes: (jax.Array): Array of option strike prices.
-    :param expires: (jax.Array): Array of option expiration times.
-    :param vols: (jax.Array): Array of option volatility values.
-    :param discount_rates: (jax.Array): Array of risk-free interest rates
-    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param spots: (Union[jax.Array, float]): Current asset price or array of prices.
+    :param strikes: (Union[jax.Array, float]): Option strike price or array of prices.
+    :param expires: (Union[jax.Array, float]): Option expiration time or array of times.
+    :param vols: (Union[jax.Array, float]): Option volatility value or array of values.
+    :param discount_rates: (Union[jax.Array, float]): Risk-free interest rate or array of rates.
+    :param are_calls: (Union[jax.Array, bool]): Boolean indicating whether option is a
+                                                call or put, or array of booleans.
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
-    :return: (jax.Array): Array of theta of the given options.
+    :return: (Union[jax.Array, float]): Theta of the given option or array of thetas.
     """
+    if jnp.isscalar(spots) or spots.shape == ():
+        return _theta_vanilla(
+            spots, strikes, expires, vols, discount_rates, are_calls, dtype
+        )
+
     return vmap(_theta_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
         spots, strikes, expires, vols, discount_rates, are_calls, dtype
     )
 
 
 def rho_vanilla(
-    spots: jax.Array,
-    strikes: jax.Array,
-    expires: jax.Array,
-    vols: jax.Array,
-    discount_rates: jax.Array,
-    are_calls: jax.Array = None,
+    spots: Union[jax.Array, float],
+    strikes: Union[jax.Array, float],
+    expires: Union[jax.Array, float],
+    vols: Union[jax.Array, float],
+    discount_rates: Union[jax.Array, float],
+    are_calls: Union[jax.Array, bool] = None,
     dtype: jnp.dtype = None,
-) -> jax.Array:
+) -> Union[jax.Array, float]:
     """
     Calculate the rho of a european option under the BS model (vectorized)
 
-    :param spots: (jax.Array): Array of current asset prices.
-    :param strikes: (jax.Array): Array of option strike prices.
-    :param expires: (jax.Array): Array of option expiration times.
-    :param vols: (jax.Array): Array of option volatility values.
-    :param discount_rates: (jax.Array): Array of risk-free interest rates
-    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param spots: (Union[jax.Array, float]): Current asset price or array of prices.
+    :param strikes: (Union[jax.Array, float]): Option strike price or array of prices.
+    :param expires: (Union[jax.Array, float]): Option expiration time or array of times.
+    :param vols: (Union[jax.Array, float]): Option volatility value or array of values.
+    :param discount_rates: (Union[jax.Array, float]): Risk-free interest rate or array of rates.
+    :param are_calls: (Union[jax.Array, bool]): Boolean indicating whether option is a
+                                                call or put, or array of booleans.
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
-    :return: (jax.Array): Array of rho of the given options.
+    :return: (Union[jax.Array, float]): Rho of the given option or array of rhos.
     """
+    if jnp.isscalar(spots) or spots.shape == ():
+        return _rho_vanilla(
+            spots, strikes, expires, vols, discount_rates, are_calls, dtype
+        )
+
     return vmap(_rho_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
         spots, strikes, expires, vols, discount_rates, are_calls, dtype
     )
 
 
 def vega_vanilla(
-    spots: jax.Array,
-    strikes: jax.Array,
-    expires: jax.Array,
-    vols: jax.Array,
-    discount_rates: jax.Array,
-    are_calls: jax.Array = None,
+    spots: Union[jax.Array, float],
+    strikes: Union[jax.Array, float],
+    expires: Union[jax.Array, float],
+    vols: Union[jax.Array, float],
+    discount_rates: Union[jax.Array, float],
+    are_calls: Union[jax.Array, bool] = None,
     dtype: jnp.dtype = None,
-) -> jax.Array:
+) -> Union[jax.Array, float]:
     """
     Calculate the vega of a european option under the BS model (vectorized)
 
-    :param spots: (jax.Array): Array of current asset prices.
-    :param strikes: (jax.Array): Array of option strike prices.
-    :param expires: (jax.Array): Array of option expiration times.
-    :param vols: (jax.Array): Array of option volatility values.
-    :param discount_rates: (jax.Array): Array of risk-free interest rates
-    :param are_calls: (jax.Array) Array of booleans indicating whether options are calls (True) or puts (False).
+    :param spots: (Union[jax.Array, float]): Current asset price or array of prices.
+    :param strikes: (Union[jax.Array, float]): Option strike price or array of prices.
+    :param expires: (Union[jax.Array, float]): Option expiration time or array of times.
+    :param vols: (Union[jax.Array, float]): Option volatility value or array of values.
+    :param discount_rates: (Union[jax.Array, float]): Risk-free interest rate or array of rates.
+    :param are_calls: (Union[jax.Array, bool]): Boolean indicating whether option is a
+                                                call or put, or array of booleans.
     :param dtype: (jnp.dtype): Data type of the output. Defaults to None.
-    :return: (jax.Array): Array of vega of the given options.
+    :return: (Union[jax.Array, float]): Vega of the given option or array of vegas.
     """
+    if jnp.isscalar(spots):
+        return _vega_vanilla(
+            spots, strikes, expires, vols, discount_rates, are_calls, dtype
+        )
+
     return vmap(_vega_vanilla, in_axes=(0, 0, 0, 0, 0, 0, None))(
         spots, strikes, expires, vols, discount_rates, are_calls, dtype
     )

--- a/tests/price_engine/test_bs.py
+++ b/tests/price_engine/test_bs.py
@@ -2,11 +2,14 @@ import jax.numpy as jnp
 
 from jaxfin.price_engine.black_scholes import european_price, delta_european, gamma_european, theta_european, rho_european, vega_european
 
+import logging
+
 import pytest
 
 TOL = 1e-3
 DTYPE = jnp.float32
 
+logging.basicConfig(level=logging.INFO)
 
 def test_one_vanilla():
     dtype = jnp.float32
@@ -65,29 +68,44 @@ def test_vanilla_batch_mixed_disc():
 
 ### Test Greeks Calculations ###
 
-@pytest.mark.parametrize("spot, strike, expire, vol, rate, e_call_delta, e_put_delta",
-                         [(100, 120, 1, 0.3, 0.0, 0.32357, -0.67643),
-                          (100, 110, 1, 0.3, 0.0, 0.43341, -0.56659),
-                          (100, 120, 1, 0.2, 0.05, 0.28719, -0.71281),
-                          (80, 150, 0.5, 0.5, 0.02, 0.05787, -0.94213),
-                          (170, 160, 0.25, 0.15, 0.01, 0.81034, -0.18966)
-                        ])
 class TestDelta:
 
-    def test_delta_bs(self, spot, strike, expire, vol, rate, e_call_delta, e_put_delta):
-        spot = jnp.array([spot], dtype=DTYPE)
-        strike = jnp.array([strike], dtype=DTYPE)
-        expire = jnp.array([expire], dtype=DTYPE)
-        vol = jnp.array([vol], dtype=DTYPE)
-        rate = jnp.array([rate], dtype=DTYPE)
-        put_flag = jnp.array([False], dtype=jnp.bool_)
-        e_call_delta = jnp.array([e_call_delta], dtype=DTYPE)
-        call_delta = delta_european(spot, strike, expire, vol, rate)
-        put_delta = delta_european(spot, strike, expire, vol, rate, are_calls=put_flag)
+    def test_delta_bs_float(self):
+        spot = jnp.array(100, dtype=DTYPE)
+        strike = jnp.array(120, dtype=DTYPE)
+        expire = jnp.array(1, dtype=DTYPE)
+        vol = jnp.array(0.3, dtype=DTYPE)
+        rate = jnp.array(0.0, dtype=DTYPE)
+        expected_delta = jnp.array(0.32357, dtype=DTYPE)
+        expected_put_delta = jnp.array(-0.67643, dtype=DTYPE)
 
-        assert jnp.isclose(call_delta, e_call_delta, atol=TOL).all()
-        assert jnp.isclose(put_delta, e_put_delta, atol=TOL).all()
-        assert jnp.isclose(call_delta - 1.0, put_delta, atol=TOL).all()
+        logging.info(f"Testing with spot={spot}, strike={strike}, expire={expire}, vol={vol}, rate={rate}")
+
+        call_delta = delta_european(spot, strike, expire, vol, rate)
+        put_delta = delta_european(spot, strike, expire, vol, rate, are_calls=False)
+
+        assert jnp.isclose(call_delta, expected_delta, atol=TOL)
+        assert jnp.isclose(put_delta, expected_put_delta, atol=TOL)
+        assert jnp.isclose(call_delta - 1.0, put_delta, atol=TOL)
+
+    def test_delta_bs(self):
+        spots = jnp.array([100, 100, 100, 80, 170], dtype=DTYPE)
+        strikes = jnp.array([120, 110, 120, 150, 160], dtype=DTYPE)
+        expires = jnp.array([1, 1, 1, 0.5, 0.25], dtype=DTYPE)
+        vols = jnp.array([0.3, 0.3, 0.2, 0.5, 0.15], dtype=DTYPE)
+        rates = jnp.array([0.0, 0.0, 0.05, 0.02, 0.01], dtype=DTYPE)
+        put_flags = jnp.array([False, False, False, False, False], dtype=jnp.bool_)
+        e_call_deltas = jnp.array([0.32357, 0.43341, 0.28719, 0.05787, 0.81034], dtype=DTYPE)
+        e_put_deltas = jnp.array([-0.67643, -0.56659, -0.71281, -0.94213, -0.18966], dtype=DTYPE)
+
+        logging.info(f"Testing with spots={spots}, strikes={strikes}, expires={expires}, vols={vols}, rates={rates}")
+
+        call_deltas = delta_european(spots, strikes, expires, vols, rates)
+        put_deltas = delta_european(spots, strikes, expires, vols, rates, are_calls=put_flags)
+
+        assert jnp.allclose(call_deltas, e_call_deltas, atol=TOL)
+        assert jnp.allclose(put_deltas, e_put_deltas, atol=TOL)
+        assert jnp.allclose(call_deltas - 1.0, put_deltas, atol=TOL)
 
 
 class TestDeltaBatch:

--- a/tests/price_engine/test_bs.py
+++ b/tests/price_engine/test_bs.py
@@ -153,6 +153,19 @@ class TestGamma:
 
         assert jnp.isclose(gamma, expected_gamma, atol=TOL).all()
 
+class TestGammaBatch:
+
+    def test_gamma_bs_vectorized(self):
+        spots = jnp.array([100, 100, 100, 80, 170], dtype=DTYPE)
+        strikes = jnp.array([120, 110, 120, 150, 160], dtype=DTYPE)
+        expires = jnp.array([1, 1, 1, 0.5, 0.25], dtype=DTYPE)
+        vols = jnp.array([0.3, 0.3, 0.2, 0.5, 0.15], dtype=DTYPE)
+        rates = jnp.array([0.0, 0.0, 0.05, 0.02, 0.01], dtype=DTYPE)
+        expected_gammas = jnp.array([0.01198, 0.01311, 0.01704, 0.00409, 0.02126], dtype=DTYPE)
+        gammas = gamma_european(spots, strikes, expires, vols, rates)
+
+        assert jnp.allclose(gammas, expected_gammas, atol=TOL)
+
 @pytest.mark.parametrize("spot, strike, expire, vol, rate, e_call_theta, e_put_theta",
                             [(100, 120, 1, 0.3, 0.0, 5.38894, 5.38894),
                             (100, 110, 1, 0.3, 0.0, 5.90058, 5.90058),


### PR DESCRIPTION
- Able to calculate the Greeks in the scalar case.
- Improved Greek computation performance leveraging `jax.jit`.
- No need to calculate the Greeks in a multidimensional way. 