### PR TITLE
21 fix heston generation paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 SHELL=/bin/bash
 LINT_PATHS=jaxfin/ tests/
 
+build:
+	python -m build
+
 pytest:
 	python -m pytest --no-header -vv --html=test_report.html --self-contained-html
 
@@ -25,11 +28,11 @@ check-codestyle:
 commit-checks: format type lint
 
 release: 
-	python -m build
+	build
 	twine upload dist/*
 
 test-release: 
-	python -m build
+	build
 	twine upload dist/* -r testpypi
 
 .PHONY: clean spelling doc lint format check-codestyle commit-checks pylint

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,16 @@ LINT_PATHS=jaxfin/ tests/
 pytest:
 	python -m pytest --no-header -vv --html=test_report.html --self-contained-html
 
+pylint:
+	pylint jaxfin --output-format=text:pylint_res.txt,colorized
+
 type: 
 	mypy ${LINT_PATHS}
 
 lint:
 	ruff check jaxfin --output-format=full
 
-complete-lint:
-	lint
-	pylint jaxfin --output-format=text:pylint_res.txt,colorized
+lint-complete: lint pylint
 
 format:
 	isort ${LINT_PATHS}
@@ -31,4 +32,4 @@ test-release:
 	python -m build
 	twine upload dist/* -r testpypi
 
-.PHONY: clean spelling doc lint format check-codestyle commit-checks
+.PHONY: clean spelling doc lint format check-codestyle commit-checks pylint

--- a/tests/models/test_gbm.py
+++ b/tests/models/test_gbm.py
@@ -1,8 +1,11 @@
 import jax.numpy as jnp
+import numpy as np
 
 from jaxfin.models.gbm import MultiGeometricBrownianMotion, UnivGeometricBrownianMotion
 
 SEED: int = 42
+
+np.random.seed(SEED)
 
 
 class TestUnivGBM:
@@ -25,7 +28,7 @@ class TestUnivGBM:
         dtype = jnp.float32
         gbm = UnivGeometricBrownianMotion(s0, mean, sigma, dtype)
 
-        stock_paths = gbm.sample_paths(SEED, 1.0, 52, 100)
+        stock_paths = gbm.sample_paths(1.0, 52, 100)
 
         assert stock_paths.shape == (52, 100)
 
@@ -53,6 +56,6 @@ class TestMultiGBM:
         corr = jnp.array([[1, 0.1], [0.1, 1]])
         dtype = jnp.float32
         gbm = MultiGeometricBrownianMotion(s0, mean, sigma, corr, dtype)
-        sample_path = gbm.sample_paths(SEED, 1.0, 52, 100)
+        sample_path = gbm.sample_paths(1.0, 52, 100)
 
         assert sample_path.shape == (52, 100, 2)

--- a/tests/models/test_heston.py
+++ b/tests/models/test_heston.py
@@ -1,8 +1,11 @@
 import jax.numpy as jnp
+import numpy as np
 
 from jaxfin.models.heston.heston import MultiHestonModel, UnivHestonModel
 
 SEED: int = 42
+
+np.random.seed(SEED)
 
 
 class TestUnivHestonModel:
@@ -42,7 +45,7 @@ class TestUnivHestonModel:
             s0, v0, mean, kappa, theta, sigma, rho, dtype=jnp.float32
         )
         paths, variance_process = heston_model.sample_paths(
-            seed=SEED, maturity=1.0, n=100, n_sim=100
+            maturity=1.0, n=100, n_sim=100
         )
 
         assert paths.shape == (100, 100)
@@ -86,7 +89,7 @@ class TestMultiHestonModel:
             s0, v0, mean, kappa, theta, sigma, corr, dtype=jnp.float32
         )
         paths, variance_processes = heston_model.sample_paths(
-            seed=SEED, maturity=1.0, n=100, n_sim=100
+            maturity=1.0, n=100, n_sim=100
         )
 
         assert paths.shape == (100, 100, 2)


### PR DESCRIPTION
Rewritten the gen paths logic in the models, now using `numpy` instead of `jax`, since with `jax` the random number generation is a little bit more tricky to configure, while with `numpy` we can just set the random seed at the beginning and then generates paths , so we don't have to give to the `sample_paths` method the random seed as input every time.